### PR TITLE
feat(component-wizard): generate atomic components using wizard

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new atoms through the wizard 1`] = `
+"export { default } from './MockComponent'
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new atoms through the wizard 2`] = `
+"import React from 'react'
+
+const MockComponent = () => {
+  return(
+    <>
+      <p>Boilerplate mock component component</p>
+    </>
+  )
+}
+
+export default MockComponent
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new atoms through the wizard 3`] = `
+"import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import MockComponent from '.'
+
+describe('MockComponent', () => {
+  it('creates short description', () => {
+    const result = TestRenderer.create(
+      <MockComponent />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new molecules through the wizard 1`] = `
+"export { default } from './MockComponent'
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new molecules through the wizard 2`] = `
+"import React from 'react'
+
+const MockComponent = () => {
+  return(
+    <>
+      <p>Boilerplate mock component component</p>
+    </>
+  )
+}
+
+export default MockComponent
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new molecules through the wizard 3`] = `
+"import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import MockComponent from '.'
+
+describe('MockComponent', () => {
+  it('creates short description', () => {
+    const result = TestRenderer.create(
+      <MockComponent />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new organisms through the wizard 1`] = `
+"export { default } from './MockComponent'
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new organisms through the wizard 2`] = `
+"import React from 'react'
+
+const MockComponent = () => {
+  return(
+    <>
+      <p>Boilerplate mock component component</p>
+    </>
+  )
+}
+
+export default MockComponent
+"
+`;
+
+exports[`Integration Test Generated App New component wizard(plop) can generate new organisms through the wizard 3`] = `
+"import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import MockComponent from '.'
+
+describe('MockComponent', () => {
+  it('creates short description', () => {
+    const result = TestRenderer.create(
+      <MockComponent />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})
+"
+`;

--- a/index.test.js
+++ b/index.test.js
@@ -1,45 +1,99 @@
+// End-to-end Integration Test
+const fs = require('fs')
 const { execSync } = require('child_process')
 const rimraf = require('rimraf')
-const { log, error } = require('./helpers/logger')
+const { error } = require('./helpers/logger')
 
 // TODO: Jest can't process coverage of spaned processes
 // May need to wrap NYC to get the coverage of all the
 // code executed here
 
-describe('Integration', () => {
-  beforeEach(() => {
-    // Cleanup the temp
-    rimraf.sync('./tmp', {}, () => {
-      log('No tmp directory to remove.')
-    })
-  })
-
-  it('Can generate a new project from the default template', async () => {
+describe('Integration Test', () => {
+describe('Generated App', () => {
+  beforeAll( async () => {
     // Run the generator expecting successful STDOUT
     try {
       await execSync('node ./index.js --no-git -- tmp', { stdio: 'inherit' })
     } catch (e) {
-      error('Failed to complete generation process.')
+      error('Failed to complete generation process.', e)
       expect(true).toEqual(false) // Force test failure
     }
-    // Generated app should be buildable
-    try {
-      await execSync('(cd tmp ; npm run build)', { stdio: 'inherit' })
-    } catch (e) {
-      error('Generated app failed to build with `npm run build`')
-      expect(true).toEqual(false) // Force test failure
-    }
-    // Generated app should be exportable
-    try {
-      await execSync('(cd tmp ; npm run export)', { stdio: 'inherit' })
-    } catch (e) {
-      error('Generated app failed to export with `npm run export`')
-      expect(true).toEqual(false) // Force test failure
-    }
-    // Cleanup the temp which verifies the tmp folder got populated
+  })
+  afterAll(() => {
+    // Cleanup the temp
     rimraf.sync('./tmp', {}, () => {
       error('No tmp directory to remove.')
       expect(true).toEqual(false) // Force test failure
     })
   })
+
+  it('can build', async () => {
+    // Generated app should be buildable
+    try {
+      await execSync('(cd tmp ; npm run build)', { stdio: 'inherit' })
+    } catch (e) {
+      error('Generated app failed to build with `npm run build`', e)
+      expect(true).toEqual(false) // Force test failure
+    }
+  })
+
+  it('can export static html', async () => {
+    // Generated app should be exportable
+    try {
+      await execSync('(cd tmp ; npm run export)', { stdio: 'inherit' })
+    } catch (e) {
+      error('Generated app failed to export with `npm run export`', e)
+      expect(true).toEqual(false) // Force test failure
+    }
+  })
+
+  describe('New component wizard(plop)', () => {
+    const componentTypes = {
+      atom: {
+        files: [
+          'index.js',
+          'MockComponent.jsx',
+          'MockComponent.test.jsx'
+        ]
+      },
+      molecule: {
+        files: [
+          'index.js',
+          'MockComponent.jsx',
+          'MockComponent.test.jsx'
+        ]
+      },
+      organism: {
+        files: [
+          'index.js',
+          'MockComponent.jsx',
+          'MockComponent.test.jsx'
+        ]
+      }
+    }
+
+    // Loop through each type of component and test the files are created
+    Object.entries(componentTypes).forEach(([componentType, data]) => {
+      it(`can generate new ${componentType}s through the wizard`, async() => {
+        const path = `tmp/components/${componentType}s/MockComponent`
+        const cmd = `(cd tmp; npm run generate -- component ${componentType} "mock component" "short description")`
+
+        try {
+          await execSync(cmd)
+        } catch (e) {
+          error(`Failed to run plop for a ${componentType}`, e)
+          expect(true).toEqual(false) // Force test failure
+        }
+
+        // Check that all expected files are generated
+        data.files.forEach((file) => {
+          expect(fs.readFileSync(`${path}/${file}`, 'utf-8')).toMatchSnapshot()
+        })
+      })
+    })
+
+    it.skip('can generate new pages through the wizard', async () => {})
+    it.skip('can generate new apis through the wizard', async () => {})
+  })
+})
 })

--- a/package.json
+++ b/package.json
@@ -106,9 +106,9 @@
     "coverageThreshold": {
       "global": {
         "branches": 0,
-        "functions": 17,
-        "lines": 7.8,
-        "statements": 8
+        "functions": 20.9,
+        "lines": 9.2,
+        "statements": 9.4
       }
     },
     "testPathIgnorePatterns": [

--- a/templates/default.json
+++ b/templates/default.json
@@ -23,6 +23,7 @@
     "jest",
     "jest-coverage-badges",
     "lint-staged",
+    "plop",
     "prettier",
     "pretty-quick",
     "react-test-renderer"
@@ -37,6 +38,7 @@
       "build": "next build",
       "export": "next export",
       "dev": "next",
+      "generate": "plop",
       "lint": "npm run lint:eslint",
       "lint:eslint": "eslint --ignore-path .gitignore \"**/*.{jsx,js}\"",
       "lint:prettier": "pretty-quick",

--- a/templates/default/CONTRIBUTING.md
+++ b/templates/default/CONTRIBUTING.md
@@ -1,3 +1,17 @@
+## New Components
+This project follows the Atomic Design pattern for components.
+* Pages
+  * APIs
+  * Components
+    * Organisms
+      * Molecules
+        * Atoms
+    * Helpers
+
+In a NextJS app, pages are stored under the `/pages/` path and APIs are at `/pages/api`. All other React components are stored in `/components/` following  Atomic Design folder structures.
+
+**Do not create new React components from scratch.** Instead, use the wizard to guide you through the process of stubbing out the necessary files and structures expected for each type of component
+
 ## Unit Tests
 
 ![Branch Code Coverage](./coverage/badge-branches.svg)

--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -55,3 +55,6 @@ Once the Docker image exists in your registry of choice (local or remote), you c
 docker run -p 0.0.0.0:3000:80 react-example/%%APPNAME%%:latest
 ```
 If you'd like to run on a different port, replace `3000` with the desired port.
+
+## Contributing
+Add new components and features using `npm run generate`. See [Contributing New Components](CONTRIBUTING.md#new-components) for more details.

--- a/templates/default/__tests__/README.md
+++ b/templates/default/__tests__/README.md
@@ -1,3 +1,5 @@
 NextJS automatically assumes any `js` or `jsx` files in `/pages` should be compiled to actual routes. This causes problems for the unit test files which are named `.test.jsx`. Therefore unit tests for pages and APIs must be placed in a `__tests__` folder.
 
 **Note:** Unit tests for components and helpers should remain in the same folder as the component themselves. Only test files for `/pages/` should be in this `__tests__` directory.
+
+The other tests that make sense to include in this folder are for root-level scripts, to avoid cluttering up the project root.

--- a/templates/default/__tests__/plopfile.test.js
+++ b/templates/default/__tests__/plopfile.test.js
@@ -1,0 +1,12 @@
+import config from '../plopfile'
+
+const mockPlop = {}
+mockPlop.load = jest.fn()
+
+describe('plopfile:global', () => {
+  it('loads the default plopfile', () => {
+    config(mockPlop)
+    expect(mockPlop.load.mock.calls.length).toEqual(1)
+    expect(mockPlop.load.mock.calls).toEqual([['./config/plop/plopfiles/default.js']])
+  })
+})

--- a/templates/default/config/plop/plopfiles/__snapshots__/defaut.test.js.snap
+++ b/templates/default/config/plop/plopfiles/__snapshots__/defaut.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`plopfile:default provides the default plop configuration 1`] = `
+Array [
+  "component",
+  Object {
+    "actions": Array [
+      Object {
+        "path": "components/{{atomicType}}s/{{properCase componentName}}/index.js",
+        "templateFile": "../templates/components/{{atomicType}}/index.js.hbs",
+        "type": "add",
+      },
+      Object {
+        "path": "components/{{atomicType}}s/{{properCase componentName}}/{{properCase componentName}}.jsx",
+        "templateFile": "../templates/components/{{atomicType}}/{{properCase atomicType}}.jsx.hbs",
+        "type": "add",
+      },
+      Object {
+        "path": "components/{{atomicType}}s/{{properCase componentName}}/{{properCase componentName}}.test.jsx",
+        "templateFile": "../templates/components/{{atomicType}}/{{properCase atomicType}}.test.jsx.hbs",
+        "type": "add",
+      },
+    ],
+    "description": "Create a component",
+    "prompts": Array [
+      Object {
+        "choices": Array [
+          "atom",
+          "molecule",
+          "organism",
+        ],
+        "message": "What level is this component?",
+        "name": "atomicType",
+        "type": "list",
+      },
+      Object {
+        "message": "Name of component?",
+        "name": "componentName",
+        "type": "input",
+      },
+      Object {
+        "message": "Short description of the component (eg: \`a list of names\`):",
+        "name": "componentDescription",
+        "type": "input",
+      },
+    ],
+  },
+]
+`;

--- a/templates/default/config/plop/plopfiles/default.js
+++ b/templates/default/config/plop/plopfiles/default.js
@@ -1,0 +1,52 @@
+module.exports = plop => {
+  const templates = '../templates'
+  plop.setGenerator('component', {
+    description: 'Create a component',
+    // User input prompts provided as arguments to the template
+    prompts: [
+      {
+        // List of options
+        type: 'list',
+        // Variable name for this input
+        name: 'atomicType',
+        // Prompt to display on command line
+        message: 'What level is this component?',
+        choices: [
+          'atom',
+          'molecule',
+          'organism'
+        ]
+      },
+      {
+        type: 'input',
+        name: 'componentName',
+        message: 'Name of component?'
+      },
+      {
+        type: 'input',
+        name: 'componentDescription',
+        message: 'Short description of the component (eg: `a list of names`):'
+      }
+    ],
+    actions: [
+      // Add the component index
+      {
+        type: 'add',
+        path: 'components/{{atomicType}}s/{{properCase componentName}}/index.js',
+        templateFile: `${templates}/components/{{atomicType}}/index.js.hbs`,
+      },
+      // Add the component file
+      {
+        type: 'add',
+        path: 'components/{{atomicType}}s/{{properCase componentName}}/{{properCase componentName}}.jsx',
+        templateFile: `${templates}/components/{{atomicType}}/{{properCase atomicType}}.jsx.hbs`,
+      },
+      // Add the unit test file
+      {
+        type: 'add',
+        path: 'components/{{atomicType}}s/{{properCase componentName}}/{{properCase componentName}}.test.jsx',
+        templateFile: `${templates}/components/{{atomicType}}/{{properCase atomicType}}.test.jsx.hbs`,
+      },
+    ],
+  });
+};

--- a/templates/default/config/plop/plopfiles/defaut.test.js
+++ b/templates/default/config/plop/plopfiles/defaut.test.js
@@ -1,0 +1,12 @@
+import config from './default'
+
+const mockPlop = {}
+mockPlop.setGenerator = jest.fn()
+
+describe('plopfile:default', () => {
+  it('provides the default plop configuration', () => {
+    config(mockPlop)
+    expect(mockPlop.setGenerator.mock.calls.length).toEqual(1)
+    expect(mockPlop.setGenerator.mock.calls[0]).toMatchSnapshot()
+  })
+})

--- a/templates/default/config/plop/templates/components/atom/Atom.jsx.hbs
+++ b/templates/default/config/plop/templates/components/atom/Atom.jsx.hbs
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const {{properCase componentName}} = () => {
+  return(
+    <>
+      <p>Boilerplate {{componentName}} component</p>
+    </>
+  )
+}
+
+export default {{properCase componentName}}

--- a/templates/default/config/plop/templates/components/atom/Atom.test.jsx.hbs
+++ b/templates/default/config/plop/templates/components/atom/Atom.test.jsx.hbs
@@ -1,0 +1,13 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import {{properCase componentName}} from '.'
+
+describe('{{properCase componentName}}', () => {
+  it('creates {{componentDescription}}', () => {
+    const result = TestRenderer.create(
+      <{{properCase componentName}} />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/templates/default/config/plop/templates/components/atom/index.js.hbs
+++ b/templates/default/config/plop/templates/components/atom/index.js.hbs
@@ -1,0 +1,1 @@
+export { default } from './{{properCase componentName}}'

--- a/templates/default/config/plop/templates/components/molecule/Molecule.jsx.hbs
+++ b/templates/default/config/plop/templates/components/molecule/Molecule.jsx.hbs
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const {{properCase componentName}} = () => {
+  return(
+    <>
+      <p>Boilerplate {{componentName}} component</p>
+    </>
+  )
+}
+
+export default {{properCase componentName}}

--- a/templates/default/config/plop/templates/components/molecule/Molecule.test.jsx.hbs
+++ b/templates/default/config/plop/templates/components/molecule/Molecule.test.jsx.hbs
@@ -1,0 +1,13 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import {{properCase componentName}} from '.'
+
+describe('{{properCase componentName}}', () => {
+  it('creates {{componentDescription}}', () => {
+    const result = TestRenderer.create(
+      <{{properCase componentName}} />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/templates/default/config/plop/templates/components/molecule/index.js.hbs
+++ b/templates/default/config/plop/templates/components/molecule/index.js.hbs
@@ -1,0 +1,1 @@
+export { default } from './{{properCase componentName}}'

--- a/templates/default/config/plop/templates/components/organism/Organism.jsx.hbs
+++ b/templates/default/config/plop/templates/components/organism/Organism.jsx.hbs
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const {{properCase componentName}} = () => {
+  return(
+    <>
+      <p>Boilerplate {{componentName}} component</p>
+    </>
+  )
+}
+
+export default {{properCase componentName}}

--- a/templates/default/config/plop/templates/components/organism/Organism.test.jsx.hbs
+++ b/templates/default/config/plop/templates/components/organism/Organism.test.jsx.hbs
@@ -1,0 +1,13 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+import {{properCase componentName}} from '.'
+
+describe('{{properCase componentName}}', () => {
+  it('creates {{componentDescription}}', () => {
+    const result = TestRenderer.create(
+      <{{properCase componentName}} />
+    ).toJSON()
+
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/templates/default/config/plop/templates/components/organism/index.js.hbs
+++ b/templates/default/config/plop/templates/components/organism/index.js.hbs
@@ -1,0 +1,1 @@
+export { default } from './{{properCase componentName}}'

--- a/templates/default/plopfile.js
+++ b/templates/default/plopfile.js
@@ -1,0 +1,3 @@
+module.exports = plop => {
+  plop.load('./config/plop/plopfiles/default.js')
+}


### PR DESCRIPTION
Adds a plop wizard to generated projects so developers can easily
create new atoms, molecules, and organisms by running the
command `npm run generate`.

Fixes #7