### PR TITLE
feat(ci): add Dependabot support in generated projects

### DIFF
--- a/create-app.js
+++ b/create-app.js
@@ -133,7 +133,10 @@ const createApp = async ({ appPath, useNpm, noGit = false, example }) => {
     })
     log()
 
-    await cpy('**', root, {
+    await cpy([
+      '**',
+      '.dependabot/**'
+    ], root, {
       parents: true,
       cwd: path.join(__dirname, 'templates', 'default'),
       rename: name => {
@@ -189,7 +192,7 @@ const createApp = async ({ appPath, useNpm, noGit = false, example }) => {
   log()
   log()
   if (!noGit) {
-    log(`-----------------------------------------------
+    log(`-GitHub----------------------------------------
 A git repo is created, but changes have not been pushed to the
 remote git server. Make sure an empy repo exists at:
   ${chalk.cyan(gitRemote)}
@@ -197,6 +200,17 @@ and then run the onetime command:
   ${chalk.cyan('git push --follow-tags push')}`)
     log(`-----------------------------------------------`)
   }
+  log()
+  log(`-Dependabot------------------------------------
+Your project is prepared with Dependabot support
+for automated management of updating dependencies
+with bugfixes and security updates. To enable it,
+you needto visit:
+  ${chalk.cyan(`https://dependabot.com `)}
+and grant Dependabot access to your GitHub
+repository.
+  `)
+  log(`-----------------------------------------------`)
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
       "global": {
         "branches": 0,
         "functions": 20,
-        "lines": 9.1,
-        "statements": 9.3
+        "lines": 9,
+        "statements": 9.2
       }
     },
     "testPathIgnorePatterns": [

--- a/templates/default/.dependabot/config.yml
+++ b/templates/default/.dependabot/config.yml
@@ -1,0 +1,14 @@
+# Dependabot is a service that automates the
+# process of keeping your dependencies up
+# to date with the latest security and bug
+# fixes. To enable it for this repo, visit
+# https://dependabot.com
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Dependabot (owned by GitHub) automates the process
of managing dependency updates. This gives the
generated projects everything they need to leverage
Dependabot.