### PR TITLE
fix: rename npm package so yarn create works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/amclin-create-react-app.svg)](https://www.npmjs.com/amclin-create-react-app) [![Build Status](https://travis-ci.org/amclin/react-project-boilerplate.svg?branch=master)](https://travis-ci.org/amclin/react-project-boilerplate)
+[![npm version](https://badge.fury.io/js/create-amclin-nextjs-app.svg)](https://www.npmjs.com/create-amclin-nextjs-app) [![Build Status](https://travis-ci.org/amclin/react-project-boilerplate.svg?branch=master)](https://travis-ci.org/amclin/react-project-boilerplate)
 
 ![Branch Code Coverage](./coverage/badge-branches.svg) ![Functions Code Coverage](./coverage/badge-functions.svg) ![Lines Code Coverage](./coverage/badge-lines.svg) ![Statements Code Coverage](./coverage/badge-statements.svg)
 
@@ -13,7 +13,7 @@ This package includes the global command for creating new React projects incorpo
 
 ### The Easy Way
 
-1. Run `npx amclin-create-react-app`
+1. Run `npx create-amclin-nextjs-app` or `yarn create amclin-nextjs-app`
 2. Create a new empty repo in GitHub with the same project name
 3. Push the new local commits up the new remote repo
 

--- a/index.js
+++ b/index.js
@@ -101,18 +101,18 @@ async function notifyUpdate() {
       const isYarn = shouldUseYarn()
 
       log()
-      log(chalk.yellow.bold('A new version of `amclin-create-react-app` is available!'))
+      log(chalk.yellow.bold('A new version of `create-amclin-nextjs-app` is available!'))
       log(`
         You can update by running:
           ${chalk.cyan(
             isYarn
-              ? 'yarn global add amclin-create-react-app'
-              : 'npm i -g amclin-create-react-app'
+              ? 'yarn global add create-amclin-nextjs-app'
+              : 'npm i -g create-amclin-nextjs-app'
           )}
       `)
       log()
       log(`But an even better option is to globally uninstall and in the future run:`)
-      log(chalk.cyan()` npx amclin-create-react-app`)
+      log(chalk.cyan()` npx create-amclin-nextjs-app`)
       log(`That way you'll always have the latest.`)
     }
   } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "amclin-create-react-app",
+  "name": "create-amclin-nextjs-app",
   "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amclin-create-react-app",
+  "name": "create-amclin-nextjs-app",
   "version": "2.8.0",
   "description": "Boilerplate repo for React apps with CICD pipelines, best practices, and code governance",
   "repository": {


### PR DESCRIPTION
`yarn create` requires that a package on the NPM registry
be prefixed with the name `create-`.

BREAKING CHANGE:
`npx amclin-create-react-app` is now `npx create-amclin-nextjs-app`

Fixes #18