### PR TITLE
ci(travis): fix travis badge URL to use .com instead of .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://badge.fury.io/js/create-amclin-nextjs-app.svg)](https://www.npmjs.com/create-amclin-nextjs-app) [![Build Status](https://travis-ci.org/amclin/react-project-boilerplate.svg?branch=master)](https://travis-ci.org/amclin/react-project-boilerplate)
+[![npm version](https://badge.fury.io/js/create-amclin-nextjs-app.svg)](https://www.npmjs.com/create-amclin-nextjs-app) [![Build Status](https://travis-ci.com/amclin/react-project-boilerplate.svg?branch=master)](https://travis-ci.com/amclin/react-project-boilerplate)
 
 ![Branch Code Coverage](./coverage/badge-branches.svg) ![Functions Code Coverage](./coverage/badge-functions.svg) ![Lines Code Coverage](./coverage/badge-lines.svg) ![Statements Code Coverage](./coverage/badge-statements.svg)
 


### PR DESCRIPTION
travis-ci.org and travis-ci.com are not interchangeable