### PR TITLE
feat: remove version locking on generated project dependencies

### DIFF
--- a/helpers/install.js
+++ b/helpers/install.js
@@ -4,7 +4,7 @@ const { log } = require('./logger')
 
 const buildYarnCommand = ({dependencies, isOnline, root, devDependencies}) => {
   const command = 'yarn'
-  const args = dependencies ? ['add', '--exact'] : ['install']
+  const args = dependencies ? ['add'] : ['install']
   if(devDependencies) {
     args.push('--dev')
   }
@@ -32,7 +32,6 @@ const buildNpmCommand = ({dependencies, devDependencies}) => {
   const args = [
     'install',
     dependencies && saveCommand,
-    dependencies && '--save-exact',
     '--loglevel',
     'error'
   ]


### PR DESCRIPTION
Generated projects should be kept up to date with their dependencies.
This removes the hard-coded version on dependencies, which would
only encourage projects to get out of date very quickly.

If a project wants to have hard locks on dependency versions, then they should explicitly manage those with lockfiles and project-specific requirements.