### PR TITLE
Fix/code coverage

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -4,17 +4,22 @@ const { execSync } = require('child_process')
 const rimraf = require('rimraf')
 const { error } = require('./helpers/logger')
 
-// TODO: Jest can't process coverage of spaned processes
-// May need to wrap NYC to get the coverage of all the
-// code executed here
-// https://github.com/amclin/react-project-boilerplate/issues/28
+const WORKAROUND_PREPEND = 'nyc --reporter none';
+
+// TODO: Once nyc major version 15 is released, update to that version and make any necessary code
+// adjustments to accommodate breaking changes (if applicable). Current version of nyc
+// relies on npm module spawn-wrap and has issues with edge cases when used in this particular
+// manner - particularly on Windows runtimes: https://github.com/facebook/jest/issues/5274#issuecomment-554657586 
+
+// Discussion thread: https://github.com/amclin/react-project-boilerplate/issues/28
 
 describe('Integration Test', () => {
 describe('Generated App', () => {
   beforeAll( async () => {
     // Run the generator expecting successful STDOUT
     try {
-      await execSync('node ./index.js --use-npm --no-git --with-ssr -- tmp', { stdio: 'inherit' })
+      // Interim workaround: https://github.com/facebook/jest/issues/3190#issuecomment-354758036
+      await execSync(`${WORKAROUND_PREPEND} node ./index.js --use-npm --no-git --with-ssr -- tmp`, { stdio: 'inherit' })
     } catch (e) {
       error('Failed to complete generation process.', e)
       expect(true).toEqual(false) // Force test failure

--- a/index.test.js
+++ b/index.test.js
@@ -4,14 +4,13 @@ const { execSync } = require('child_process')
 const rimraf = require('rimraf')
 const { error } = require('./helpers/logger')
 
-const WORKAROUND_PREPEND = 'nyc --reporter none';
-
 // TODO: Once nyc major version 15 is released, update to that version and make any necessary code
 // adjustments to accommodate breaking changes (if applicable). Current version of nyc
 // relies on npm module spawn-wrap and has issues with edge cases when used in this particular
 // manner - particularly on Windows runtimes: https://github.com/facebook/jest/issues/5274#issuecomment-554657586 
 
 // Discussion thread: https://github.com/amclin/react-project-boilerplate/issues/28
+const WORKAROUND_PREPEND = 'nyc --reporter none';
 
 describe('Integration Test', () => {
 describe('Generated App', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-amclin-nextjs-app",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4180,10 +4180,25 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "argparse": {
@@ -5307,6 +5322,41 @@
         }
       }
     },
+    "caching-transform": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+      "dev": true,
+      "requires": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -6411,6 +6461,15 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -6882,6 +6941,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+      "dev": true
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -7804,6 +7869,44 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -8826,6 +8929,15 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -9668,6 +9780,15 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
       "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+      "dev": true,
+      "requires": {
+        "append-transform": "^1.0.0"
+      }
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
@@ -11171,6 +11292,12 @@
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -11457,6 +11584,23 @@
           "requires": {
             "camelcase": "^4.1.0"
           }
+        }
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
         }
       }
     },
@@ -15821,6 +15965,86 @@
       "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
       "dev": true
     },
+    "nyc": {
+      "version": "14.1.1",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "caching-transform": "^3.0.2",
+        "convert-source-map": "^1.6.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.2.3",
+        "uuid": "^3.3.2",
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -16074,6 +16298,12 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -16169,6 +16399,18 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "package-hash": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "pako": {
       "version": "1.0.10",
@@ -17285,6 +17527,12 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
@@ -17727,6 +17975,15 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -18386,6 +18643,31 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spawn-wrap": {
+      "version": "1.4.3",
+      "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+      "integrity": "sha1-gbdnDhcMyiR9gL9frwz7cTvc+Eg=",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.us.bank-dns.com:443/artifactory/api/npm/registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,13 @@
       "^.+\\.[t|j]sx?$": "babel-jest"
     }
   },
+  "nyc": {
+    "check-coverage": true,
+    "branches": 1.5,
+    "functions": 22.5,
+    "lines": 11,
+    "statements": 11
+  },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
       "eslint"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pretest": "npm run lint",
     "semantic-release": "npx semantic-release",
     "start": "next start",
-    "test": "jest --coverage",
+    "test": "nyc jest --coverage",
     "test:badges": "jest-coverage-badges"
   },
   "devDependencies": {
@@ -55,6 +55,7 @@
     "jest-coverage-badges": "^1.1.2",
     "lint-staged": "^9.4.0",
     "next": "^9.1.1",
+    "nyc": "^14.1.1",
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0",
     "prop-types": "^15.7.2",
@@ -84,6 +85,7 @@
     ]
   },
   "jest": {
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{js,jsx,ts,tsx}"
     ],
@@ -97,11 +99,7 @@
       "/__mocks__/"
     ],
     "coverageReporters": [
-      "clover",
-      "json",
-      "json-summary",
-      "lcov",
-      "text"
+      "none"
     ],
     "coverageThreshold": {
       "global": {


### PR DESCRIPTION
Basic approach using the nyc workaround involving `spawn-wrap`

TODO comment updated, basic nyc config added to match expected coverage thresholds defined for Jest.