### PR TITLE
fix(ci): bump semantic-release dependency for gitlab users

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:eslint": "eslint --ignore-path .gitignore \"**/*.{jsx,js}\"",
     "lint:prettier": "pretty-quick",
     "pretest": "npm run lint",
-    "semantic-release": "npx semantic-release",
+    "semantic-release": "npx --package semantic-release@^15.14.0 semantic-release",
     "start": "next start",
     "test": "jest --coverage",
     "test:badges": "jest-coverage-badges"


### PR DESCRIPTION
Bumps the minimum version of semantic-releases which solves issues in downstream projects using gitlab.

semantic-release v15.13.1 and earlier don't support the features
introduced in @semantic-release/gitlab v4.1.0
See https://github.com/semantic-release/gitlab/issues/121