### PR TITLE
fix(deps): rollback CommanderJS to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9906,9 +9906,9 @@
       }
     },
     "commander": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
-      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   ],
   "dependencies": {
     "chalk": "3.0.0",
-    "commander": "5.0.0",
+    "commander": "=4.1.1",
     "cpy": "8.1.0",
     "cross-spawn": "7.0.1",
     "deepmerge": "^4.1.1",


### PR DESCRIPTION
CommanderJS 5.0.0 breaks compatibility causing the generator to fail.
Fixes #279