### PR TITLE
fix(deps): [security] bump NextJS in generated projects from 9.2.0 to 9.3.3

### DIFF
--- a/templates/default.json
+++ b/templates/default.json
@@ -8,7 +8,7 @@
     "graphql",
     "graphql-tag",
     "isomorphic-unfetch",
-    "next@^9.2.0",
+    "next@^9.3.3",
     "prop-types",
     "react@^16.12.0",
     "react-dom@^16.12.0"


### PR DESCRIPTION
Security vulnerability in NextJS < 9.3.2

See CVE-2020-5284

Generator itself already handled in #302 