### PR TITLE
fix(deps): unpin dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,19 +174,19 @@
     "node 10"
   ],
   "dependencies": {
-    "chalk": "4.0.0",
+    "chalk": "^4.0.0",
     "commander": "^5.0.0",
-    "cpy": "8.1.0",
+    "cpy": "^8.1.0",
     "cross-spawn": "7.0.2",
     "deepmerge": "^4.1.1",
     "git-user-name": "^2.0.0",
-    "got": "11.1.2",
-    "make-dir": "3.1.0",
-    "promisepipe": "3.0.0",
-    "prompts": "2.3.2",
+    "got": "^11.1.2",
+    "make-dir": "^3.1.0",
+    "promisepipe": "^3.0.0",
+    "prompts": "^2.3.2",
     "replace-in-file": "^6.0.0",
-    "tar": "6.0.2",
-    "update-check": "1.5.4",
-    "validate-npm-package-name": "3.0.0"
+    "tar": "^6.0.2",
+    "update-check": "^1.5.4",
+    "validate-npm-package-name": "^3.0.0"
   }
 }


### PR DESCRIPTION
Using ranges instead of fixed dependencies allows for newer versions
with security updates and bug fixes to be used automatically. It also
reduces the need to manually deal with future updates since Dependabot
can automate merges based on the allowable semantic version ranges.