### PR TITLE
refactor: simplify logger implementation

### DIFF
--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-console */
-const log = (message = '') => console.log(message)
-const error = (message, e = '') => console.error(message, e)
+const { log, error } = console
 
 module.exports = {
   log,

--- a/package.json
+++ b/package.json
@@ -114,10 +114,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 47,
+        "branches": 46.9,
         "functions": 59,
-        "lines": 43,
-        "statements": 42.5
+        "lines": 42.9,
+        "statements": 42.7
       }
     },
     "testPathIgnorePatterns": [


### PR DESCRIPTION
Don't need explicit function defaults when just passing through 1:1
to console. Reduces branches, but also total line count, so total
code coverage is slightly reduced.