### PR TITLE
feat(deps): include `jest-coverage-badges` only when needed

### DIFF
--- a/helpers/init-git.test.js
+++ b/helpers/init-git.test.js
@@ -9,23 +9,29 @@ describe('init-git', () => {
       expect(canUseGit()).toEqual(true)
     })
     it('returns false if git cli is not available', () => {
-      execSync.mockImplementationOnce(() => { throw new Error('git not available') })
+      execSync.mockImplementationOnce(() => {
+        throw new Error('git not available')
+      })
       expect(canUseGit()).toEqual(false)
     })
   })
   describe('initGit()', () => {
     beforeAll(() => {
       execSync.mockReturnValue(true)
-      initGit('./',{ gitRemote: 'git+https://example.com'})
+      initGit('./', { gitRemote: 'git+https://example.com' })
     })
     it('initializes the git repo', () => {
       expect(execSync).toBeCalledWith(expect.stringContaining(`git init`))
     })
     it('adds a remote origin', () => {
-      expect(execSync).toBeCalledWith(expect.stringContaining(`git remote add origin git+https://example.com`))
+      expect(execSync).toBeCalledWith(
+        expect.stringContaining(`git remote add origin git+https://example.com`)
+      )
     })
     it('adds a remote origin', () => {
-      expect(execSync).toBeCalledWith(expect.stringContaining(`git remote add origin`))
+      expect(execSync).toBeCalledWith(
+        expect.stringContaining(`git remote add origin`)
+      )
     })
   })
   describe('commitFirst()', () => {
@@ -37,17 +43,29 @@ describe('init-git', () => {
     it('adds all files to the git stage', () => {
       expect(execSync).toBeCalledWith(expect.stringContaining(`git add .`))
     })
-    it('adds the code coveragfe badges to the git stage', () => {
-      expect(execSync).toBeCalledWith(expect.stringContaining(`git add coverage/badge-*.svg -f`))
+    it('adds the code coverage badges to the git stage', () => {
+      expect(execSync).toBeCalledWith(
+        expect.stringContaining(`git add coverage/badge-*.svg -f`)
+      )
     })
     it('makes an initial commit to the git repo', () => {
-      expect(execSync).toBeCalledWith(expect.stringContaining(`git commit --no-verify -m "chore: initial commit`))
+      expect(execSync).toBeCalledWith(
+        expect.stringContaining(
+          `git commit --no-verify -m "chore: initial commit`
+        )
+      )
     })
     it('tags the commit with an initial version', () => {
-      expect(execSync).toBeCalledWith(expect.stringContaining(`git tag -a v${version} -m "release v${version} for initial repo creation"`))
+      expect(execSync).toBeCalledWith(
+        expect.stringContaining(
+          `git tag -a v${version} -m "release v${version} for initial repo creation"`
+        )
+      )
     })
-    it('rejects a promise when git cli can\'t be detected.', async () => {
-      execSync.mockImplementationOnce(() => { throw new Error('git not available') })
+    it("rejects a promise when git cli can't be detected.", async () => {
+      execSync.mockImplementationOnce(() => {
+        throw new Error('git not available')
+      })
       let result = true
       await commitFirst({ version }).catch(() => {
         result = false
@@ -56,7 +74,9 @@ describe('init-git', () => {
     })
     it.skip('rejects a promise when git errors', async () => {
       canUseGit.mockImplementationOnce(() => true)
-      execSync.mockImplementationOnce(() => { throw new Error('git fails') })
+      execSync.mockImplementationOnce(() => {
+        throw new Error('git fails')
+      })
       let result = true
       await commitFirst({ version }).catch(() => {
         result = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-amclin-nextjs-app",
-  "version": "3.14.4",
+  "version": "3.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9999,32 +9999,6 @@
           "dev": true,
           "requires": {
             "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
-    "jest-coverage-badges": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/jest-coverage-badges/-/jest-coverage-badges-1.1.2.tgz",
-      "integrity": "sha512-44A7i2xR6os8+fWk8ZRM6W4fKiD2jwKOLU9eB3iTIIWACd9RbdvmiCNpQZTOsUBhKvz7aQ/ASFhu5JOEhWUOlg==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semantic-release": "npx --package semantic-release@^17.0.4 semantic-release",
     "start": "next start",
     "test": "jest --coverage",
-    "test:badges": "jest-coverage-badges"
+    "test:badges": "npx -y jest-coverage-badges"
   },
   "devDependencies": {
     "@apollo/react-hooks": "^3.1.3",
@@ -61,7 +61,6 @@
     "husky": "^6.0.0",
     "isomorphic-unfetch": "^3.0.0",
     "jest": "^26.0.1",
-    "jest-coverage-badges": "^1.1.2",
     "lint-staged": "^10.0.1",
     "next": "^9.5.1",
     "prettier": "^2.0.1",

--- a/templates/default.json
+++ b/templates/default.json
@@ -38,7 +38,6 @@
     "eslint-plugin-react-hooks",
     "husky",
     "jest",
-    "jest-coverage-badges",
     "lint-staged",
     "plop",
     "prettier",
@@ -62,7 +61,7 @@
       "semantic-release": "npx semantic-release",
       "start": "next start",
       "test": "jest --coverage",
-      "test:badges": "jest-coverage-badges"
+      "test:badges": "npx -y jest-coverage-badges"
     },
     "commitlint": {
       "extends": ["@commitlint/config-angular"]


### PR DESCRIPTION
Switches to dynamically install when running the badge generation step using npx instead
of including immediately as a dev dependency. This solves some security implications
caused by the module having some outdated dependencies that are reported by `npm audit`
and cause a unit test failure (see #681)

This improves the situation for `jest-coverage-badges` in particular, but does not provide
a universal solution for other dependencies that could cause the same problem in the future.